### PR TITLE
#8: add python scripts to server image during build

### DIFF
--- a/build/server/Dockerfile
+++ b/build/server/Dockerfile
@@ -16,6 +16,7 @@ RUN mv build /etc/autofeed/app && \
     mv node_modules /etc/autofeed/app && \
     mv package.json /etc/autofeed/app
 
+COPY ./scripts/*.py /etc/autofeed/py-scripts
 COPY ./data/environment/env.server /etc/autofeed/app/.env
 
 WORKDIR /etc/autofeed/app


### PR DESCRIPTION
Closes #8 

Adds `./scripts/*.py` to `/etc/autofeed/py-scripts` during server image build.

---

This can be tested/confirmed to work by building locally, running `bash` in the image, then checking the contents of `/etc/autofeed/py-scripts`.

![image](https://user-images.githubusercontent.com/44447928/159565444-1728ea3f-d3f7-42e8-b4bd-0d33caad2986.png)