### PR TITLE
#15: container tz setting

### DIFF
--- a/build/os/start-container.sh
+++ b/build/os/start-container.sh
@@ -2,6 +2,7 @@
 
 CONTAINER=$1
 
+TZ=$(cat /etc/timezone)
 if [[ $CONTAINER == "server" ]]; then
   docker run \
         --name autofeed-server \
@@ -9,6 +10,7 @@ if [[ $CONTAINER == "server" ]]; then
         --restart always \
         --privileged \
         -p 8080:8080 \
+        -e TZ=$TZ \
         --mount type=bind,src=/etc/autofeed/data,dst=/etc/autofeed/data \
         -d autofeed-server node .
 elif [[ $CONTAINER == "client" ]]; then
@@ -18,5 +20,6 @@ elif [[ $CONTAINER == "client" ]]; then
         --link autofeed-server \
         --restart always \
         -p 3000:3000 \
+        -e TZ=$TZ \
         -d autofeed-client yarn start
 fi


### PR DESCRIPTION
Closes #15 

---

Sets the `TZ` environment variable when starting containers. Uses the host's `/etc/timezone` setting. This should be set during image flash by an end user