### PR TITLE
#4: support for GPIO config editing

### DIFF
--- a/client/components/GpioConfig.vue
+++ b/client/components/GpioConfig.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="w-full border border-dashed border-blue-500 p-3 rounded">
+    <div class="border-b border-gray-300 pb-1 mb-3">
+      <div class="float-right">
+        <button
+          :class="saveButtonClass"
+          :disabled="!this.saveButtonEnabled"
+          @click="saveConfig"
+        >Save</button>
+      </div>
+      <h1 class="text-lg">{{ config.name }}</h1>
+      <div class="clear-both" />
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-2">
+      <div class="text-sm">
+        <label>Device ID</label>
+        <input
+          class="text-input mt-1 font-mono bg-gray-100"
+          type="text"
+          :value="config.id"
+          disabled
+        />
+      </div>
+      <div class="text-sm">
+        <label>Device Name</label>
+        <input
+          class="text-input mt-1 font-mono"
+          type="text"
+          :value="editedConfig.name || config.name"
+          @change="changeName"
+        />
+      </div>
+      <div class="text-sm">
+        <label>GPIO Pin</label>
+        <input
+          class="text-input mt-1 font-mono"
+          type="number"
+          :value="editedConfig.pin || config.pin"
+          @change="changePin"
+        />
+      </div>
+      <div class="text-sm">
+        <label>Normal Condition</label>
+        <div class="mt-2.5">
+          <ToggleSwitch
+            class="inline"
+            :enabled="(editedConfig.normal || config.normal) === 'on'"
+            @toggle="(enabled) => this.changeNormalCondition(enabled)"
+          />
+          <div class="inline ml-3 font-mono">
+            {{ (editedConfig.normal || config.normal).toUpperCase() }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import ToggleSwitch from "./ToggleSwitch";
+export default {
+  name: 'GpioConfig',
+  components: {ToggleSwitch},
+  props: {
+    config: {
+      required: true,
+      type: Object,
+    },
+  },
+  data () {
+    return {
+      editedConfig: {
+        name: undefined,
+        pin: undefined,
+        normal: undefined,
+      },
+    };
+  },
+  computed: {
+    saveButtonEnabled () {
+      return this.editedConfig.name !== undefined || this.editedConfig.pin !== undefined || this.editedConfig.normal !== undefined;
+    },
+    saveButtonClass () {
+      const style = [
+        'px-3',
+        'py-1',
+        'border',
+        'rounded',
+      ];
+
+      if (this.saveButtonEnabled) {
+        style.push(...[
+          'cursor-pointer',
+          'bg-blue-500',
+          'border-blue-600',
+          'hover:bg-blue-600',
+          'text-white',
+        ]);
+      } else {
+        style.push(...[
+          'cursor-default',
+          'bg-blue-400',
+          'border-blue-500',
+          'text-gray-100',
+        ]);
+      }
+
+      return style.join(' ');
+    },
+  },
+  methods: {
+    changeName (event) {
+      this.editedConfig.name = event.target.value;
+    },
+    changePin (event) {
+      this.editedConfig.pin = Number(event.target.value);
+    },
+    changeNormalCondition (enabled) {
+      this.editedConfig.normal = (enabled) ? 'on' : 'off';
+    },
+
+    saveConfig () {
+      this.$emit('saved', this.config.id, {
+        name: this.editedConfig.name || this.config.name,
+        pin: this.editedConfig.pin || this.config.pin,
+        normal: this.editedConfig.normal || this.config.normal,
+      });
+
+      this.editedConfig = {
+        name: undefined,
+        pin: undefined,
+        normal: undefined,
+      };
+    },
+  },
+};
+</script>

--- a/client/components/Navbar.vue
+++ b/client/components/Navbar.vue
@@ -1,0 +1,68 @@
+<template>
+  <nav class="bg-white shadow">
+    <div class="w-full md:w-2/3 ml-auto mr-auto md:px-0 px-3">
+      <div class="flex justify-between h-16">
+        <div class="flex">
+          <div class="flex-shrink-0 flex items-center">
+            DIYAutoFeed
+          </div>
+          <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
+            <nuxt-link
+              v-for="item in nav"
+              :key="item.id"
+              :to="item.href"
+              class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
+            >{{ item.text }}</nuxt-link>
+          </div>
+        </div>
+
+        <div class="-mr-2 flex items-center sm:hidden">
+          <!-- Mobile menu button -->
+          <button
+            type="button"
+            class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+            aria-controls="mobile-menu"
+            aria-expanded="false"
+            @click="menuOpen = !menuOpen"
+          >
+            <font-awesome-icon :icon="['fas', 'bars']" />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="sm:hidden" id="mobile-menu" v-if="menuOpen">
+      <div class="pt-2 pb-3 space-y-1">
+        <nuxt-link
+          v-for="item in nav"
+          :key="item.id"
+          :to="item.href"
+          class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+        >{{ item.text }}</nuxt-link>
+      </div>
+    </div>
+  </nav>
+</template>
+<script>
+export default {
+  name: 'Navbar',
+  data () {
+    return {
+      nav: [
+        {
+          id: 'dashboard',
+          text: 'Dashboard',
+          icon: '',
+          href: '/',
+        },
+        {
+          id: 'gpio-config',
+          text: 'GPIO Configuration',
+          icon: '',
+          href: '/gpio-config',
+        }
+      ],
+      menuOpen: false,
+    };
+  },
+};
+</script>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -10,13 +10,16 @@
       </div>
     </div>
     <div :class="bodyClass" v-else>
+      <Navbar />
       <Nuxt />
     </div>
   </div>
 </template>
 <script>
+import Navbar from "../components/Navbar";
 export default {
   components: {
+    Navbar
   },
   data () {
     return {

--- a/client/pages/gpio-config.vue
+++ b/client/pages/gpio-config.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="w-full md:w-2/3 ml-auto mr-auto md:px-0 px-3">
+    <h1 class="text-2xl mt-5 border-b pb-2 mb-3">GPIO Configuration</h1>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div v-for="config in gpioConfig" :key="config.id">
+        <GpioConfig
+          :config="config"
+          @saved="updateGpioConfig"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import ToggleSwitch from "../components/ToggleSwitch";
+import GpioConfig from "../components/GpioConfig";
+export default {
+  name: 'GpioConfigPage',
+  components: {GpioConfig, ToggleSwitch},
+  data () {
+    return {
+      editedConfigs: {},
+    };
+  },
+  computed: {
+    gpioConfig () {
+      return this.$store.getters['api/config'].gpio;
+    },
+  },
+  methods: {
+    updateGpioConfig (gpioId, config) {
+      this.$store.dispatch('api/saveConfig', { id: gpioId, ...config });
+    },
+  },
+};
+</script>

--- a/client/store/api.js
+++ b/client/store/api.js
@@ -19,6 +19,25 @@ export const actions = {
       }).catch(reject);
     });
   },
+  saveConfig ({ commit, getters}, modifiedConfig) {
+    return new Promise((resolve, reject) => {
+      const existingConfigs = getters.config.gpio || [];
+      for (const i in existingConfigs) {
+        const config = existingConfigs[i];
+        if (config.id === modifiedConfig.id) {
+          existingConfigs[i] = modifiedConfig;
+          break;
+        }
+      }
+
+      axios.put('/api/gpio-config', {
+        gpioConfig: existingConfigs,
+      }).then((res) => {
+        commit('SET_CONFIG', res.data);
+        resolve(res.data);
+      }).catch(reject);
+    });
+  },
   saveSchedules ({ commit, getters }, modifiedSchedule) {
     return new Promise((resolve, reject) => {
       const existingSchedules = getters.schedules || [];

--- a/server/src/http/controllers/ConfigurationController.ts
+++ b/server/src/http/controllers/ConfigurationController.ts
@@ -12,6 +12,7 @@ export default class ConfigurationController extends AbstractController
         this.updateSchedules();
         this.getDeviceStatus();
         this.controlDevice();
+        this.updateGpioConfig();
     }
 
     protected index (): void
@@ -26,6 +27,15 @@ export default class ConfigurationController extends AbstractController
         this.app.put('/schedules', async (req: Request, res: Response) => {
             const schedules = req.body.schedules || [];
             await Config.instance.updateSchedules(schedules);
+            return res.status(200).json(Config.instance.getConfig());
+        });
+    }
+
+    protected updateGpioConfig (): void
+    {
+        this.app.put('/gpio-config', async (req: Request, res: Response) => {
+            const gpioConfig = req.body.gpioConfig || [];
+            await Config.instance.updateGpioConfig(gpioConfig);
             return res.status(200).json(Config.instance.getConfig());
         });
     }

--- a/server/src/services/config.ts
+++ b/server/src/services/config.ts
@@ -62,4 +62,10 @@ export default class Config
         this.config.schedules = schedules;
         await fs.writeFileSync(util.format('%s/base_configuration.json', process.env.DATA_DIR), JSON.stringify(this.config));
     }
+
+    public async updateGpioConfig (gpioConfig: Array<IGPIOConfig>): Promise<void>
+    {
+        this.config.gpio = gpioConfig;
+        await fs.writeFileSync(util.format('%s/base_configuration.json', process.env.DATA_DIR), JSON.stringify(this.config));
+    }
 }

--- a/server/tests/unit/services/config.test.ts
+++ b/server/tests/unit/services/config.test.ts
@@ -260,4 +260,80 @@ describe ('test Config', () => {
         expect(writeFileSync).toHaveBeenCalledWith('/path/to/data/base_configuration.json', expectedJsonConfig);
         expect(config.getConfig()).toEqual(JSON.parse(expectedJsonConfig));
     });
+
+    test ('test updateGpioConfig', async () => {
+        const writeFileSync = jest.fn();
+        fs.writeFileSync = writeFileSync;
+
+        const configData: IConfig = {
+            gpio: [
+                {
+                    id: 'GPIO_TEST',
+                    pin: 12,
+                    normal: 'off',
+                    name: 'Gpio Test',
+                },
+                {
+                    id: 'GPIO_TEST2',
+                    pin: 5,
+                    normal: 'off',
+                    name: 'Gpio Test2',
+                },
+            ],
+            paths: {
+                scripts: {
+                    python: '/path/to/python/scripts',
+                },
+                application: '/path/to/app',
+            },
+            schedules: [],
+        };
+        const config = new Config(configData);
+
+        const updatedGpioConfigs: any = [
+            {
+                id: 'GPIO_TEST',
+                pin: 13,
+                normal: 'on',
+                name: 'Gpio Test Updated',
+            },
+            {
+                id: 'GPIO_TEST2',
+                pin: 5,
+                normal: 'off',
+                name: 'Gpio Test2',
+            },
+        ];
+
+        const expectedJsonConfig = JSON.stringify({
+            gpio: [
+                {
+                    id: 'GPIO_TEST',
+                    pin: 13,
+                    normal: 'on',
+                    name: 'Gpio Test Updated',
+                },
+                {
+                    id: 'GPIO_TEST2',
+                    pin: 5,
+                    normal: 'off',
+                    name: 'Gpio Test2',
+                },
+            ],
+            paths: {
+                scripts: {
+                    python: '/path/to/python/scripts',
+                },
+                application: '/path/to/app',
+            },
+            schedules: [],
+        });
+
+        process.env.DATA_DIR = '/path/to/data';
+        await config.updateGpioConfig(updatedGpioConfigs);
+
+        expect(writeFileSync).toHaveBeenCalledTimes(1);
+        expect(writeFileSync).toHaveBeenCalledWith('/path/to/data/base_configuration.json', expectedJsonConfig);
+        expect(config.getConfig()).toEqual(JSON.parse(expectedJsonConfig));
+    });
 });


### PR DESCRIPTION
Closes #4 

Adds ability to modify GPIO config. Only supports modification of existing devices via the UI, but the server side supports adding/removing as well.

![image](https://user-images.githubusercontent.com/44447928/160257227-551f53c0-ba58-4828-b632-0cd485308f84.png)
