### PR TITLE
#26: MQTT info icon fix

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diyautofeed-ui",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/client/pages/mqtt-config.vue
+++ b/client/pages/mqtt-config.vue
@@ -24,7 +24,7 @@
         </div>
         <input type="text" class="text-input font-mono" v-model="editedConfig.nodePrefix" placeholder="autofeed_1" />
         <div class="rounded border border-blue-500 bg-blue-300 shadow p-2 text-blue-800 mt-1">
-          <font-awesome-icon :icon="['fas', 'info']" class="mr-3" />
+          <font-awesome-icon :icon="['fas', 'info']" class="mr-3 w-4 h-4 inline" />
           This should be a unique identifier for this AutoFeed device. For example,
           <span class="font-mono text-gray-800">autofeed_1</span>, which will produce entities with IDs
           such as <span class="font-mono text-gray-800">switch.autofeed_1_egress_pump</span>.

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autofeed-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Complete backend system for compatible auto-feed systems",
   "main": "build/index.js",
   "repository": "git@github.com:StarlightAutomation/autofeed-backend.git",


### PR DESCRIPTION
Closes #26 

---

Uses `w-4 h-4` and `inline` on the info icon on the mqtt config page